### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/ids_project/ids_app/views.py
+++ b/ids_project/ids_app/views.py
@@ -390,6 +390,6 @@ def toggle_ids(request):
         logger.info(f"IDS status toggled to: {status.is_active}")
         return JsonResponse({'is_active': status.is_active})
     except Exception as e:
-        error_message = f"Error toggling IDS: {str(e)}\n{traceback.format_exc()}"
-        logger.error(error_message)
-        return JsonResponse({'error': error_message}, status=500)
+        error_message = f"Error toggling IDS: {str(e)}"
+        logger.error(f"{error_message}\n{traceback.format_exc()}")
+        return JsonResponse({'error': "An internal error has occurred. Please try again later."}, status=500)


### PR DESCRIPTION
Fixes [https://github.com/Ate329/IDS/security/code-scanning/4](https://github.com/Ate329/IDS/security/code-scanning/4)

To fix the problem, we need to modify the code to log the detailed error message and stack trace on the server while returning a generic error message to the user. This approach ensures that sensitive information is not exposed to potential attackers while still allowing developers to diagnose issues using the server logs.

1. Modify the exception handling block to log the detailed error message and stack trace.
2. Return a generic error message to the user instead of the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
