### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/ids_project/ids_app/views.py
+++ b/ids_project/ids_app/views.py
@@ -304,7 +304,8 @@ def get_csv_data(request):
             'flags': dict(flag_counter.most_common(5))
         })
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=500)
+        logger.error("An error occurred while processing the CSV data: %s", str(e))
+        return JsonResponse({'error': 'An internal error has occurred!'}, status=500)
 
 
 @require_http_methods(["GET"])


### PR DESCRIPTION
Fixes [https://github.com/Ate329/IDS/security/code-scanning/3](https://github.com/Ate329/IDS/security/code-scanning/3)

To fix the problem, we should log the detailed exception message on the server and return a generic error message to the client. This approach ensures that sensitive information is not exposed to the user while still allowing developers to access the necessary details for debugging.

1. Import the `logger` module if not already imported.
2. Replace the line that returns the exception message with a line that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
